### PR TITLE
feat: send user-agent header

### DIFF
--- a/src/lib/newsie.ex
+++ b/src/lib/newsie.ex
@@ -2,4 +2,18 @@ defmodule Newsie do
   @moduledoc """
   Documentation for `Newsie`.
   """
+
+  @version Mix.Project.config()[:version]
+
+  @doc """
+  HTTP User-Agent to send to remote APIs
+
+  ### Example
+      iex> Newsie.user_agent()
+      "Newsie/#{@version}"
+  """
+  @spec user_agent() :: String.t()
+  def user_agent do
+    "Newsie/#{@version}"
+  end
 end

--- a/src/lib/providers/news_api.ex
+++ b/src/lib/providers/news_api.ex
@@ -108,10 +108,15 @@ defmodule Newsie.Providers.NewsApi do
   end
 
   defp client do
+    headers = [
+      {"x-api-key", api_key()},
+      {"user-agent", Newsie.user_agent()}
+    ]
+
     middleware = [
       {Tesla.Middleware.BaseUrl, "http://newsapi.org/v2/"},
       Tesla.Middleware.JSON,
-      {Tesla.Middleware.Headers, [{"x-api-key", api_key()}]}
+      {Tesla.Middleware.Headers, headers}
     ]
 
     Tesla.client(middleware)

--- a/src/lib/providers/newsriver.ex
+++ b/src/lib/providers/newsriver.ex
@@ -106,11 +106,16 @@ defmodule Newsie.Providers.Newsriver do
   end
 
   defp client do
+    headers = [
+      {"authorization", api_key()},
+      {"user-agent", Newsie.user_agent()}
+    ]
+
     middleware = [
       Tesla.Middleware.Logger,
       {Tesla.Middleware.BaseUrl, "https://api.newsriver.io/v2/"},
       Tesla.Middleware.JSON,
-      {Tesla.Middleware.Headers, [{"authorization", api_key()}]}
+      {Tesla.Middleware.Headers, headers}
     ]
 
     Tesla.client(middleware)


### PR DESCRIPTION
Create a standard header as `Newsie/#{version}` and send it with requests.