### PR TITLE
chore(formatter): increase line length for tests

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,8 +20,8 @@ jobs:
           # only test the linting on the oldest and newest supported versions
           - elixir: "1.10"
             otp: 22
-          - elixir: "1.7"
-            otp: 19
+          - elixir: "1.8"
+            otp: 20
 
     steps:
       - uses: actions/checkout@v2

--- a/src/.formatter.exs
+++ b/src/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib}/**/*.{ex,exs}"],
+  subdirectories: ["test"]
 ]

--- a/src/test/.formatter.exs
+++ b/src/test/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  inputs: ["{mix,.formatter}.exs", "/**/*.{ex,exs}"],
+  line_length: 200
+]

--- a/src/test/lib/provider_config_test.exs
+++ b/src/test/lib/provider_config_test.exs
@@ -41,16 +41,14 @@ defmodule Newsie.ProviderConfigTest do
     end
 
     test "with config present" do
-      assert [api_key: "bogus", timeout: 100] =
-               ProviderConfig.provider_app_config(Newsie.Providers.FakeProvider)
+      assert [api_key: "bogus", timeout: 100] = ProviderConfig.provider_app_config(Newsie.Providers.FakeProvider)
     end
   end
 
   describe "get_provider_config/1" do
     # app config is set in config.exs for a FakeProvider
     test "env vars override app config" do
-      assert [api_key: "newkey", timeout: 100] =
-               ProviderConfig.get_provider_config(Newsie.Providers.FakeProvider)
+      assert [api_key: "newkey", timeout: 100] = ProviderConfig.get_provider_config(Newsie.Providers.FakeProvider)
     end
   end
 end


### PR DESCRIPTION
Sometimes we need long lines in testing, such as long strings. The formatter makes it even uglier and adds no value in these cases. So, use custom format rules for tests.