### PR TITLE
refactor: rename provider config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Configuration
 -------------
 
 News APIs require authentication, usually with a simple API key/token.
-Check the documentation for each provider and the configuration provider `Newsie.ProviderConfig`.
+Check the documentation for each provider and the configuration provider `Newsie.Config`.
 
 Configuration can be set with Elixir application config or with environment variables.
 

--- a/src/lib/newsie.ex
+++ b/src/lib/newsie.ex
@@ -20,4 +20,14 @@ defmodule Newsie do
   @doc "Get the current version of this library."
   @spec version() :: binary()
   def version, do: @version
+
+  @doc "Get a list of avaialble provider modules"
+  @spec providers() :: [atom()]
+  def providers do
+    [
+      Newsie.Providers.CurrentsApi,
+      Newsie.Providers.NewsApi,
+      Newsie.Providers.Newsriver
+    ]
+  end
 end

--- a/src/lib/newsie/config.ex
+++ b/src/lib/newsie/config.ex
@@ -1,4 +1,4 @@
-defmodule Newsie.ProviderConfig do
+defmodule Newsie.Config do
   @env_prefix "NEWSIE_"
 
   @moduledoc """
@@ -28,6 +28,11 @@ defmodule Newsie.ProviderConfig do
   `NEWSIE_<provider_name>_<param_name>`
   """
 
+  @spec get_all_provider_config :: [{atom(), keyword()}]
+  def get_all_provider_config() do
+    for mod <- Newsie.providers(), cfg = get_provider_config(mod), do: {mod, cfg}
+  end
+
   @spec get_provider_config(atom) :: keyword
   def get_provider_config(provider) do
     app_config = provider_app_config(provider)
@@ -48,7 +53,7 @@ defmodule Newsie.ProviderConfig do
   Fetching the config for the provider:
 
   ```
-  Newsie.ProviderConfig.provider_app_config(Newsie.Providers.DocProvider)
+  Newsie.Config.provider_app_config(Newsie.Providers.DocProvider)
   [api_key: "mykey"]
   ```
   """
@@ -64,7 +69,7 @@ defmodule Newsie.ProviderConfig do
 
   ### Example
       iex> System.put_env("NEWSIE_DOC_PROVIDER_API_KEY", "mykey")
-      ...> Newsie.ProviderConfig.provider_env_vars("DocProvider")
+      ...> Newsie.Config.provider_env_vars("DocProvider")
       [api_key: "mykey"]
   """
   @spec provider_env_vars(atom() | binary()) :: keyword()

--- a/src/lib/newsie/config.ex
+++ b/src/lib/newsie/config.ex
@@ -28,8 +28,24 @@ defmodule Newsie.Config do
   `NEWSIE_<provider_name>_<param_name>`
   """
 
-  @spec get_all_provider_config :: [{atom(), keyword()}]
-  def get_all_provider_config() do
+  @doc """
+  Get configuration for all providers.
+
+  Returns a list of 2-element tuples with the module atom and config `Keyword`.
+
+  ### Example
+
+  ```elixir
+  Newsie.Config.get_all_provider_configs()
+  [
+    {Newsie.Providers.CurrentsApi, [api_key: "currents_api_key"]},
+    {Newsie.Providers.NewsApi, [api_key: "news_api_key"]},
+    {Newsie.Providers.Newsriver, [api_key: "newsriver_key"]}
+  ]
+  ```
+  """
+  @spec get_all_provider_configs :: [{atom(), keyword()}]
+  def get_all_provider_configs do
     for mod <- Newsie.providers(), cfg = get_provider_config(mod), do: {mod, cfg}
   end
 

--- a/src/lib/newsie/provider.ex
+++ b/src/lib/newsie/provider.ex
@@ -1,0 +1,19 @@
+defmodule Newsie.Provider do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Newsie.Article
+
+      @doc """
+      Get current configuration for this provider.
+
+      See `Newsie.Config` for details on how configuration is loaded.
+      """
+      @spec config() :: keyword()
+      def config do
+        Newsie.Config.get_provider_config(__MODULE__)
+      end
+    end
+  end
+end

--- a/src/lib/newsie/providers/currents_api.ex
+++ b/src/lib/newsie/providers/currents_api.ex
@@ -6,17 +6,13 @@ defmodule Newsie.Providers.CurrentsApi do
 
   Requires `:api_key` to use.
 
-  See `Newsie.ProviderConfig` for documentation on how to configure providers.
+  See `Newsie.Config` for documentation on how to configure providers.
 
   [Currents API]: https://www.currentsapi.services
   """
 
-  alias Newsie.Article
+  use Newsie.Provider
 
-  @spec config :: keyword
-  def config do
-    Newsie.ProviderConfig.get_provider_config(__MODULE__)
-  end
 
   @doc """
   Search for news articles

--- a/src/lib/newsie/providers/currents_api.ex
+++ b/src/lib/newsie/providers/currents_api.ex
@@ -13,7 +13,6 @@ defmodule Newsie.Providers.CurrentsApi do
 
   use Newsie.Provider
 
-
   @doc """
   Search for news articles
 

--- a/src/lib/newsie/providers/news_api.ex
+++ b/src/lib/newsie/providers/news_api.ex
@@ -6,17 +6,12 @@ defmodule Newsie.Providers.NewsApi do
 
   Requires `:api_key` to use.
 
-  See `Newsie.ProviderConfig` for documentation on how to configure providers.
+  See `Newsie.Config` for documentation on how to configure providers.
 
   [News API]: https://newsapi.org/
   """
 
-  alias Newsie.Article
-
-  @spec config :: keyword
-  def config do
-    Newsie.ProviderConfig.get_provider_config(__MODULE__)
-  end
+  use Newsie.Provider
 
   @spec top_headlines(any) :: {:error, any()} | {:ok, [Article.t()]}
   def top_headlines(query) do

--- a/src/lib/newsie/providers/newsriver.ex
+++ b/src/lib/newsie/providers/newsriver.ex
@@ -6,17 +6,12 @@ defmodule Newsie.Providers.Newsriver do
 
   Requires `:api_key` to use.
 
-  See `Newsie.ProviderConfig` for documentation on how to configure providers.
+  See `Newsie.Config` for documentation on how to configure providers.
 
   [Newsriver]: https://newsriver.io/
   """
 
-  alias Newsie.Article
-
-  @spec config :: keyword
-  def config do
-    Newsie.ProviderConfig.get_provider_config(__MODULE__)
-  end
+  use Newsie.Provider
 
   @doc """
   Search for news articles with a SQL-like query

--- a/src/test/newsie/config_test.exs
+++ b/src/test/newsie/config_test.exs
@@ -1,7 +1,7 @@
-defmodule Newsie.ProviderConfigTest do
+defmodule Newsie.ConfigTest do
   use ExUnit.Case
 
-  alias Newsie.ProviderConfig
+  alias Newsie.Config
 
   setup_all do
     env_vars = [
@@ -22,33 +22,33 @@ defmodule Newsie.ProviderConfigTest do
 
   describe "provider_env_vars/1" do
     test "with no matching env vars" do
-      assert [] == ProviderConfig.provider_env_vars("bogus_provider")
+      assert [] == Config.provider_env_vars("bogus_provider")
     end
 
     test "finds config for the provider" do
       assert [api_key: "asdqwe123", timeout: "1000"] ==
-               ProviderConfig.provider_env_vars("MyProvider")
+               Config.provider_env_vars("MyProvider")
     end
 
     test "finds config for another provider" do
-      assert [api_key: "key1"] == ProviderConfig.provider_env_vars("other_provider")
+      assert [api_key: "key1"] == Config.provider_env_vars("other_provider")
     end
   end
 
   describe "provider_app_config/1" do
     test "with no config present" do
-      assert [] = ProviderConfig.provider_app_config(Newsie.Providers.NoSuchProvider)
+      assert [] = Config.provider_app_config(Newsie.Providers.NoSuchProvider)
     end
 
     test "with config present" do
-      assert [api_key: "bogus", timeout: 100] = ProviderConfig.provider_app_config(Newsie.Providers.FakeProvider)
+      assert [api_key: "bogus", timeout: 100] = Config.provider_app_config(Newsie.Providers.FakeProvider)
     end
   end
 
   describe "get_provider_config/1" do
     # app config is set in config.exs for a FakeProvider
     test "env vars override app config" do
-      assert [api_key: "newkey", timeout: 100] = ProviderConfig.get_provider_config(Newsie.Providers.FakeProvider)
+      assert [api_key: "newkey", timeout: 100] = Config.get_provider_config(Newsie.Providers.FakeProvider)
     end
   end
 end


### PR DESCRIPTION
* Rename `ProviderConfig` to just `Config` to keep things simple
* Introduce `Newsie.Provider` with `using` macro to standardise defining the `config` function for providers.