### PR TITLE
feat: add common query interface

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,6 +19,9 @@ check:
 docker/build:
 	docker build --tag $(DOCKER_TAG) --build-arg ELIXIR_VER=$(ELIXIR_VER) .
 
+docker/iex: docker/build
+	docker run --rm -it -v $(PWD):/opt/code $(DOCKER_TAG) iex -S mix
+
 docker/test: docker/build
 	docker run --rm -v $(PWD):/opt/code $(DOCKER_TAG) mix test
 

--- a/src/lib/newsie/article.ex
+++ b/src/lib/newsie/article.ex
@@ -13,7 +13,8 @@ defmodule Newsie.Article do
           content: String.t(),
           structured_content: String.t() | nil,
           source_name: String.t() | nil,
-          language: Newsie.Languages.code2() | nil
+          language: Newsie.Languages.code2() | nil,
+          country: Newsie.Countries.code2() | nil
         }
 
   defstruct [
@@ -26,6 +27,7 @@ defmodule Newsie.Article do
     :content,
     :structured_content,
     :source_name,
-    :language
+    :language,
+    :country
   ]
 end

--- a/src/lib/newsie/provider.ex
+++ b/src/lib/newsie/provider.ex
@@ -1,9 +1,22 @@
 defmodule Newsie.Provider do
   @moduledoc false
 
+  @doc """
+  Query for news articles given the criteria in `Newsie.Query`
+
+  This method is standard across all providers to provide a common interface.
+
+  It is likely that the `Newsie.Query` is not capable of exploiting the full
+  query capabilities of the API. If more advanced querying is required, use
+  the other access functions in this module.
+  """
+  @callback query(Newsie.Query.t()) :: {:ok, [Newsie.Article.t()]} | {:error, term()}
+
   defmacro __using__(_opts) do
     quote do
-      alias Newsie.Article
+      alias Newsie.{Article, Query}
+
+      @behaviour Newsie.Provider
 
       @doc """
       Get current configuration for this provider.

--- a/src/lib/newsie/providers/currents_api.ex
+++ b/src/lib/newsie/providers/currents_api.ex
@@ -13,6 +13,26 @@ defmodule Newsie.Providers.CurrentsApi do
 
   use Newsie.Provider
 
+  @impl true
+  def query(%Query{} = query) do
+    query
+    |> render_query()
+    |> search()
+  end
+
+  @spec render_query(Query.t()) :: keyword()
+  def render_query(%Query{} = query) do
+    query
+    |> Query.criteria()
+    |> Map.take([:language, :country, :start_date, :end_date])
+    |> Enum.map(fn
+      {:country, value} -> {:country, value |> to_string() |> String.upcase()}
+      {:start_date, value} -> {:start_date, DateTime.to_iso8601(value)}
+      {:end_date, value} -> {:end_date, DateTime.to_iso8601(value)}
+      {key, value} -> {key, value}
+    end)
+  end
+
   @doc """
   Search for news articles
 

--- a/src/lib/newsie/providers/news_api.ex
+++ b/src/lib/newsie/providers/news_api.ex
@@ -13,6 +13,15 @@ defmodule Newsie.Providers.NewsApi do
 
   use Newsie.Provider
 
+  @impl true
+  def query(%Query{} = query) do
+    query
+    |> Query.criteria()
+    |> Map.take([:country])
+    |> Map.to_list()
+    |> top_headlines()
+  end
+
   @spec top_headlines(any) :: {:error, any()} | {:ok, [Article.t()]}
   def top_headlines(query) do
     case Tesla.get(client(), "/top-headlines", query: query) do

--- a/src/lib/newsie/providers/newsriver.ex
+++ b/src/lib/newsie/providers/newsriver.ex
@@ -126,7 +126,8 @@ defmodule Newsie.Providers.Newsriver do
       date: parse_timestamp(data["publishDate"] || data["discoverDate"]),
       content: data["text"],
       structured_content: data["structuredText"],
-      language: Newsie.Languages.parse_code(data["language"])
+      language: Newsie.Languages.parse_code(data["language"]),
+      country: Newsie.Countries.parse_code(Kernel.get_in(data, ["website", "countryCode"]))
     }
   end
 

--- a/src/lib/newsie/query.ex
+++ b/src/lib/newsie/query.ex
@@ -1,0 +1,182 @@
+defmodule Newsie.Query do
+  @moduledoc "Provider-agnostic structured query"
+
+  alias __MODULE__
+  alias Newsie.{Countries, Languages}
+
+  @type t :: %__MODULE__{
+          language: Languages.code2(),
+          country: Countries.code2(),
+          start_date: DateTime.t(),
+          end_date: DateTime.t(),
+          limit: non_neg_integer()
+        }
+
+  defstruct [
+    :language,
+    :country,
+    :start_date,
+    :end_date,
+    :limit
+  ]
+
+  @doc """
+  Build a query from a `Map` or `Keyword` of params.
+
+  Parameters are parsed and converted as necessary to create a proper Query.
+
+  ### Example
+      <!-- Can't use the ~U[] sigil until dropping support for Elixir < 1.9 -->
+
+      iex> Newsie.Query.new(language: "EN", country: "Australia", end_date: ~D[2020-06-15])
+      %Newsie.Query{
+        language: :en,
+        country: :au,
+        start_date: nil,
+        end_date: %DateTime{
+          year: 2020, month: 06, day: 15,
+          hour: 0, minute: 0, second: 0,
+          time_zone: "Etc/UTC", zone_abbr: "UTC", utc_offset: 0, std_offset: 0
+        }
+      }
+
+      iex> Newsie.Query.new(language: "German", country: "CH", start_date: ~D[2020-06-15])
+      %Newsie.Query{
+        language: :de,
+        country: :ch,
+        start_date: %DateTime{
+          year: 2020, month: 06, day: 15,
+          hour: 0, minute: 0, second: 0,
+          time_zone: "Etc/UTC", zone_abbr: "UTC", utc_offset: 0, std_offset: 0
+        }
+      }
+  """
+  @spec new(keyword() | map()) :: t()
+  def new(params) do
+    Enum.reduce(params, %Query{}, fn {param, value}, query ->
+      apply(__MODULE__, :"put_#{param}", [query, value])
+    end)
+  end
+
+  @doc """
+  Get query criteria that are present (i.e. not `nil`) as a `Map`
+
+  ### Example
+      iex> query = %Newsie.Query{country: :jp, language: nil}
+      ...> Newsie.Query.criteria(query)
+      %{country: :jp}
+  """
+  @spec criteria(t()) :: map()
+  def criteria(%Query{} = query) do
+    Map.new(for {k, v} <- Map.from_struct(query), v != nil, do: {k, v})
+  end
+
+  @doc """
+  Set the `start_date` on the query.
+
+  Accepts a `Date` or `DateTime`.
+  """
+  @spec put_start_date(t(), Date.t() | DateTime.t()) :: t()
+  def put_start_date(%Query{} = q, %Date{} = date) do
+    put_start_date(q, date_to_datetime(date))
+  end
+
+  def put_start_date(%Query{} = q, %DateTime{} = dt) do
+    Map.put(q, :start_date, dt)
+  end
+
+  @doc """
+  Set the `end_date` on the query.
+
+  Accepts a `Date` or `DateTime`.
+  """
+  @spec put_end_date(t(), Date.t() | DateTime.t()) :: t()
+  def put_end_date(%Query{} = q, %Date{} = date) do
+    put_end_date(q, date_to_datetime(date))
+  end
+
+  def put_end_date(%Query{} = q, %DateTime{} = dt) do
+    Map.put(q, :end_date, dt)
+  end
+
+  @doc """
+  Set the `country` on the query.
+
+  Accepts a country code atom, country code string, or country name string.
+
+  ### Example
+      iex> Newsie.Query.put_country(%Query{}, "Singapore")
+      %Newsie.Query{country: :sg}
+
+      iex> Newsie.Query.put_country(%Query{}, "AU")
+      %Newsie.Query{country: :au}
+
+      iex> Newsie.Query.put_country(%Query{}, :ch)
+      %Newsie.Query{country: :ch}
+  """
+  @spec put_country(t(), Countries.code2() | Countries.name()) :: t()
+  def put_country(%Query{} = q, code) when is_atom(code) do
+    Map.put(q, :country, Countries.parse_code(code))
+  end
+
+  def put_country(%Query{} = q, <<code::binary-size(2)>>) do
+    Map.put(q, :country, Countries.parse_code(code))
+  end
+
+  def put_country(%Query{} = q, name) when is_binary(name) do
+    put_country(q, Countries.name_to_code(name))
+  end
+
+  @doc """
+  Set the `language` on the query.
+
+  Accepts a language code atom, language code string, or language name string.
+
+  ### Example
+      iex> Newsie.Query.put_language(%Query{}, "Japanese")
+      %Newsie.Query{language: :ja}
+
+      iex> Newsie.Query.put_language(%Query{}, "EN")
+      %Newsie.Query{language: :en}
+
+      iex> Newsie.Query.put_language(%Query{}, :de)
+      %Newsie.Query{language: :de}
+  """
+  @spec put_language(t(), Languages.code2() | Languages.name()) :: t()
+  def put_language(%Query{} = q, code) when is_atom(code) do
+    Map.put(q, :language, Languages.parse_code(code))
+  end
+
+  def put_language(%Query{} = q, <<code::binary-size(2)>>) do
+    Map.put(q, :language, Languages.parse_code(code))
+  end
+
+  def put_language(%Query{} = q, name) when is_binary(name) do
+    put_language(q, Languages.name_to_code(name))
+  end
+
+  @doc """
+  Set the `limit` on the query.
+
+  Only accepts a non-negative integer.
+  """
+  @spec put_limit(t(), non_neg_integer()) :: t()
+  def put_limit(%Query{} = q, limit) when is_integer(limit) and limit >= 0 do
+    Map.put(q, :limit, limit)
+  end
+
+  defp date_to_datetime(%Date{year: year, month: month, day: day}) do
+    %DateTime{
+      year: year,
+      month: month,
+      day: day,
+      hour: 0,
+      minute: 0,
+      second: 0,
+      time_zone: "Etc/UTC",
+      zone_abbr: "UTC",
+      utc_offset: 0,
+      std_offset: 0
+    }
+  end
+end

--- a/src/test/newsie/query_test.exs
+++ b/src/test/newsie/query_test.exs
@@ -1,0 +1,7 @@
+defmodule Newsie.QueryTest do
+  use ExUnit.Case, async: true
+
+  alias Newsie.Query
+
+  doctest Query
+end


### PR DESCRIPTION
Add a `Query` structure that can hold common parameters like language and country, Then each provider can convert these to a query as needed. It will likely not exploit the full query capability of every provider, but for basic usage, this allows for a provider-agnostic way to find news.