### PR TITLE
chore(deps): use normal dev and test mix envs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      MIX_ENV: lint
+      MIX_ENV: test
 
     defaults:
       run:

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,8 +13,8 @@ test-watch:
 
 check:
 	mix format --check-formatted
-	mix credo --strict
-	mix dialyzer --quiet
+	env MIX_ENV=test mix credo --strict
+	env MIX_ENV=test mix dialyzer --quiet
 
 docker/build:
 	docker build --tag $(DOCKER_TAG) --build-arg ELIXIR_VER=$(ELIXIR_VER) .

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,15 +6,15 @@ DOCKER_TAG := newsie_elixir_$(ELIXIR_VER)
 all: priv/data/iso-639-3.tab priv/data/iso-3166.tab test check
 
 test:
-	env MIX_ENV=test mix test
+	mix test
 
 test-watch:
 	env MIX_ENV=test mix test.watch
 
 check:
 	mix format --check-formatted
-	env MIX_ENV=lint mix credo --strict
-	env MIX_ENV=lint mix dialyzer --quiet
+	mix credo --strict
+	mix dialyzer --quiet
 
 docker/build:
 	docker build --tag $(DOCKER_TAG) --build-arg ELIXIR_VER=$(ELIXIR_VER) .

--- a/src/config/config.exs
+++ b/src/config/config.exs
@@ -6,7 +6,7 @@ if Mix.env() == :test do
     format: "$date $time [$level] $metadata$message\n"
 
   config :mix_test_watch,
-    tasks: ["test", "format --check-formatted"]
+    tasks: ["test", "credo --strict", "format --check-formatted"]
 
   config :tesla, adapter: Tesla.Mock
 

--- a/src/mix.exs
+++ b/src/mix.exs
@@ -56,15 +56,13 @@ defmodule Newsie.MixProject do
       {:tesla, "~> 1.3.0"},
       {:jason, "~> 1.0"},
 
-      # linter-only
-      {:credo, "~> 1.4", only: :lint, runtime: false},
-      {:dialyxir, "~> 1.0", only: :lint, runtime: false},
-
-      # docs-only
+      # dev only
       {:ex_doc, "~> 0.22", only: :dev, runtime: false},
 
-      # test-only
-      {:mix_test_watch, "~> 1.0", only: :test, runtime: false}
+      # test only
+      {:mix_test_watch, "~> 1.0", only: :test, runtime: false},
+      {:credo, "~> 1.4", only: :test, runtime: false},
+      {:dialyxir, "~> 1.0", only: :test, runtime: false}
     ]
   end
 end


### PR DESCRIPTION
I didn't give Elixir enough credit for how it organises dependencies. I had assumed anything I specify as a `dev` or `test` dependency would also cause apps that include this lib as a dependency to fetch those. Not so! So, now we're free to use the normal dev and test envs. Sweet.